### PR TITLE
bug - cannot nest a parser within a parser

### DIFF
--- a/hotxlfp/grammarparser/parser.py
+++ b/hotxlfp/grammarparser/parser.py
@@ -44,14 +44,14 @@ class Parser(object):
         self.tabmodule = modname + "_" + "parsetab"
 
         # Build the lexer and parser
-        lex.lex(module=lexer, debug=self.debug)
-        yacc.yacc(module=self,
+        self.lex = lex.lex(module=lexer, debug=self.debug)
+        self.yacc = yacc.yacc(module=self,
                   debug=self.debug,
                   debugfile=self.debugfile,
                   tabmodule=self.tabmodule)
 
     def parse(self, input):
-        return yacc.parse(input)
+        return self.yacc.parse(input)
 
     def run(self):
         while 1:


### PR DESCRIPTION
You cannot nest another parser as a function within the parser because `yacc` is being used in a global way.

Code to reproduce:
```python

import hotxlfp

def parse(formula):
    parser = hotxlfp.Parser(debug=True)
    setattr(parser, '_name', 'p_init')
    result = parser.parse(formula)
    return result['result']

parser2 = hotxlfp.Parser(debug=True)
setattr(parser2, '_name', 'p_ext')
parser2.set_function('EVAL', parse)
parser2.parse('EVAL("1+1")') # result = 2
parser2.parse('EVAL("1+1")') # result = None
```